### PR TITLE
#6 - Add admin feature

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,29 @@
+class Admin::UsersController < AdminsController
+  before_action :authenticate_admin!
+  before_action :set_user, only: [:edit, :update]
+
+  def index
+    @users = User.all
+  end
+
+  def edit; end
+
+  def update
+    @user.update user_params
+    redirect_to users_path
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(
+      :first_name, :last_name, :title, :phone,
+      :address, :city, :state, :zip,
+      :year_attended, :email
+    )
+  end
+end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,0 +1,14 @@
+class AdminsController < ApplicationController
+  before_action :authenticate_admin!
+  layout 'admin'
+
+  def index
+    redirect_to users_path
+  end
+
+  protected
+
+  def authenticate_admin!
+    redirect_to root_path unless current_user.admin?
+  end
+end

--- a/app/views/admin/users.html.slim
+++ b/app/views/admin/users.html.slim
@@ -1,0 +1,19 @@
+.row
+  .col-md-12
+    - unless @users.empty?
+        table.table.table-striped
+          tr
+            th Name
+            th Phone
+            th Email
+            th Year Attended
+
+          - @users.each do |user|
+            tr
+              td.name          = "#{user.first_name} #{user.last_name}"
+              td.phone         = user.phone
+              td.email         = user.email
+              td.year_attended = user.year_attended
+    - else
+      p
+        | No users found. Get some folks to sign up!

--- a/app/views/admin/users/edit.html.slim
+++ b/app/views/admin/users/edit.html.slim
@@ -1,0 +1,43 @@
+/ = bootstrap_devise_error_messages!
+.panel.panel-default.devise-bs
+  .panel-heading
+    h4= t('.title', :resource => @user, :default => "Edit User ")
+  .panel-body
+    = form_for(@user, :url => user_path, :html => { :method => :put }) do |f|
+      .form-group
+        .col-md-2
+          = f.label :title
+          = f.text_field :title, autofocus: true, class: "form-control"
+        .col-md-5
+          = f.label :first_name
+          = f.text_field :first_name, autofocus: true, class: "form-control", required: true
+        .col-md-5
+          = f.label :last_name
+          = f.text_field :last_name, autofocus: true, class: "form-control", required: true
+      .form-group
+        .col-md-6
+          = f.label :address
+          = f.text_field :address, autofocus: true, class: "form-control"
+        .col-md-3
+          = f.label :city
+          = f.text_field :city, autofocus: true, class: "form-control"
+        .col-md-1
+          = f.label :state
+          = f.text_field :state, autofocus: true, class: "form-control"
+        .col-md-2
+          = f.label :zip
+          = f.text_field :zip, autofocus: true, class: "form-control"
+      .form-group
+        .col-md-4
+          = f.label :phone
+          = f.phone_field :phone, autofocus: true, class: "form-control"
+        .col-md-8
+          = f.label :email
+          = f.email_field :email, autofocus: true, class: "form-control"
+
+      br
+      .form-group
+      = f.submit t('.update', :default => "Update"), class: "btn btn-primary", style: 'margin-top:20px;'
+p
+= link_to t('.back', :default => 'Back'), :back
+

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -1,0 +1,25 @@
+h1
+  | Users
+.row
+  .col-md-12
+    - unless @users.empty?
+        table.table.table-striped
+          tr
+            th Name
+            th Phone
+            th Email
+            th Year Attended
+            th Edit
+          - @users.each do |user|
+            tr
+              td.name          = "#{user.first_name} #{user.last_name}"
+              td.phone         = user.phone
+              td.email         = user.email
+              td.year_attended = user.year_attended
+              td 
+                a.btn.btn-success href=edit_user_path(user)
+                  i.fa.fa-cogs
+    - else
+      p
+        | No users found. Get some folks to sign up!
+

--- a/app/views/layouts/admin.html.slim
+++ b/app/views/layouts/admin.html.slim
@@ -20,16 +20,11 @@ html
             span.icon-bar
             span.icon-bar
             span.icon-bar
-          a.navbar-brand href="/"  GovSchool
+          = link_to 'GovSchool Admin', admins_path, class: 'navbar-brand'
         #bs-example-navbar-collapse-1.collapse.navbar-collapse
           ul.nav.navbar-nav
-            li class=('active' if current_page?(landing_pages_about_path))
-              = link_to('About', landing_pages_about_path)
-            li class=('active' if current_page?(landing_pages_contact_path))
-              = link_to('Contact', landing_pages_contact_path)
-            - if user_signed_in? && current_user.admin?
-              li class=('active' if current_page?(admins_path))
-                = link_to('Admin', admins_path)
+            li class=('active' if current_page?(users_path))
+              = link_to('Users', users_path)
           ul.nav.navbar-nav.navbar-right
             - if user_signed_in?
               li.dropdown

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,12 @@ Rails.application.routes.draw do
   get 'landing_pages/about'
   get 'landing_pages/contact'
 
+  resources :admins, only: [:index] do
+    collection do
+      resources :users, only: [:index, :edit, :update], controller: 'admin/users'
+    end
+  end
+
   devise_for :users, controllers: {
     omniauth_callbacks: 'users/omniauth_callbacks',
     passwords:          'users/passwords',

--- a/db/migrate/20161025092243_add_admin_to_users.rb
+++ b/db/migrate/20161025092243_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160704003354) do
+ActiveRecord::Schema.define(version: 20161025092243) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "users", force: :cascade do |t|
-    t.string   "first_name",                          null: false
-    t.string   "last_name",                           null: false
+    t.string   "first_name",                             null: false
+    t.string   "last_name",                              null: false
     t.string   "title"
     t.string   "phone"
     t.string   "address"
@@ -25,18 +25,19 @@ ActiveRecord::Schema.define(version: 20160704003354) do
     t.string   "state"
     t.string   "zip"
     t.integer  "year_attended"
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.string   "email",                  default: "",    null: false
+    t.string   "encrypted_password",     default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",          default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
     t.inet     "last_sign_in_ip"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
+    t.boolean  "admin",                  default: false
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["first_name"], name: "index_users_on_first_name", using: :btree
     t.index ["last_name"], name: "index_users_on_last_name", using: :btree


### PR DESCRIPTION
Issue: #6 

**Admin Feature**

Admins are not different from ordinary users except that they have access to `/admins` namespaced routes. For now, we only have these routes for users:
- `/admins/users` => Lists users for admin
- `/admins/users/:id/edit` => Lets admin edit a single user, with the same interface as users edit theirs.

**What changed with this pr?**

- Added a admin controller namespace, along with initial users controller
- Added `admin?` boolean field to users, which lets us check if the user is admin or not by calling `user.admin?`
- Added an admin report to show all users, and edit them. Admins have authorization to edit any user.
- If user is admin, when logged in, s/he sees `Admin` element in the menu, which navigates her/him to admin panel.